### PR TITLE
switchの不具合対応

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -56,6 +56,9 @@ function setInitialColorMode() {
   const currentColorMode = getInitialColorMode();
   console.log(currentColorMode);
 
+  const element = document.documentElement
+  element.style.setProperty("--initial-color-mode", currentColorMode)
+
   if(currentColorMode === "dark") {
     document.documentElement.setAttribute("data-theme", "dark");
   }

--- a/pages/index.js
+++ b/pages/index.js
@@ -20,6 +20,14 @@ export default function Home() {
     }
   }, [darkTheme]);
 
+  useEffect(() => {
+    const root = window.document.documentElement;
+    const initialColorValue = root.style.getPropertyValue(
+      "--initial-color-mode"
+    )
+    setDarkTheme(initialColorValue == "dark");
+  }, []);
+
   return (
     <div>
       <div className="container">


### PR DESCRIPTION
読み込み->ダークモードに切り替え->再読み込みした際に、
スイッチがオフになってる状態なのにダークモードになってたので調整。

- _document.jsにstyleと--initial-color-modeの値を追加
- useEffectで--initial-color-modeの値を追加・切り替え

（どうしてこれで動くかはわからん...）